### PR TITLE
Use Gevent Workers, Tune Nginx, Connect to DB for Valid Requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .idea/*
 gatling_testing_v1/*
 dump.rdb
+bruno_test.sh

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -7,4 +7,4 @@ COPY validators.py /app
 COPY api.py /app
 COPY wsgi.py /app
 COPY test_api.py /app
-CMD gunicorn -w 8 --bind 0.0.0.0:5000 wsgi:app
+CMD gunicorn -w 8 --bind 0.0.0.0:5000 wsgi:app -k 'gevent'

--- a/app/api.py
+++ b/app/api.py
@@ -138,8 +138,8 @@ def search_warriors():
     db = connect_to_db()
 
     cursor = db.cursor()
-    sql = "SELECT * FROM warriors WHERE name LIKE %s LIMIT 50"
-    val = ("%" + search_term + "%",)
+    sql = "SELECT * FROM warriors WHERE name = %s LIMIT 50"
+    val = (search_term,)
 
     try:
         cursor.execute(sql, val)

--- a/app/api.py
+++ b/app/api.py
@@ -1,9 +1,12 @@
 from flask import Flask, request, jsonify
 from flask_caching import Cache
 from datetime import datetime
+from gevent import monkey
 import mysql.connector
 import uuid
 from validators import validate_fight_skills
+
+monkey.patch_all()
 
 app = Flask(__name__)
 

--- a/app/api.py
+++ b/app/api.py
@@ -84,6 +84,7 @@ def create_warrior():
     try:
         cursor.execute(sql, values)
         db.commit()
+        cache.set(f"view//warrior/{id}", {}, timeout=60)
 
         return {}, 201, {"Location": f"/warrior/{id}"}
 

--- a/app/api.py
+++ b/app/api.py
@@ -51,7 +51,6 @@ def validate_dob(dob):
 # POST request that saves a new warrior entry into the database
 @app.route("/warrior", methods=["POST"])
 def create_warrior():
-    db = connect_to_db()
     data = request.json
 
     # Check name, dob, and fight_skills keys are in the request body
@@ -77,11 +76,12 @@ def create_warrior():
     fight_skills = data.get("fight_skills")
 
     fight_skills_list_string = ",".join(fight_skills)
-    cursor = db.cursor()
     sql = "INSERT INTO warriors (id, name, dob, fight_skills) VALUES (%s, %s, %s, %s)"
     values = (id, name, dob, fight_skills_list_string)
 
     try:
+        db = connect_to_db()
+        cursor = db.cursor()
         cursor.execute(sql, values)
         db.commit()
         cache.set(f"view//warrior/{id}", {}, timeout=60)

--- a/app/api.py
+++ b/app/api.py
@@ -132,10 +132,10 @@ def search_term_none():
 @app.route("/warrior", methods=["GET"])
 @cache.cached(timeout=60, make_cache_key=get_search_term, unless=search_term_none)
 def search_warriors():
-    db = connect_to_db()
     search_term = get_search_term()
     if not search_term:
         return jsonify({"message": "Bad Request"}), 400
+    db = connect_to_db()
 
     cursor = db.cursor()
     sql = "SELECT * FROM warriors WHERE name LIKE %s LIMIT 50"

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -25,3 +25,4 @@ redis==5.0.3
 six==1.16.0
 tzdata==2024.1
 Werkzeug==3.0.2
+gevent==24.2.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       - loadbalancing
     depends_on:
       - app_1
+    healthcheck:
+      test: curl --fail http://localhost:9999/ || exit 1
 
   redis:
     image: redis:latest

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,5 @@
 upstream app_1 {
-    server app_1:5000;
+    server app_1:5000 max_fails=3;
 }
 
 server {
@@ -8,6 +8,8 @@ server {
     include /etc/nginx/mime.types;
 
     location / {
+        proxy_read_timeout 300;
+        proxy_connect_timeout 75s;
         proxy_pass http://app_1/;
     }
 }


### PR DESCRIPTION
Files modified:
- Dockerfile - Added -k option to use gevent workers
- api.py - Added gevent monkey patching, moved db connection function call after the validators for the POST and GET requests, Add caching to the POST request
- requirements.txt - Added gevent module
- docker-compose.yml - Added healthcheck directive
- nginx.conf - Added max_fails to upstream server setting, Added proxy_read_timeout and proxy_connect_timeout

Purpose:
The changes made in this branch incrementally improved performance by decreasing the KO %. The moving of the db connection function after the validation functions decreased the total number of db connections made during the stress test. In the POST request handler, the location-contents key-value pair are cached after inserting the record into the database.